### PR TITLE
shift size doesn't really matter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function(array) {
   var readable = new (require('stream').Readable)({ objectMode: true });
-  readable._read = function(size) {
-    readable.push(array.shift(size));
+  readable._read = function() {
+    readable.push(array.shift());
     if (!array.length) {
       readable.push(null);
     }


### PR DESCRIPTION
Checked the documentation of [Array.shift](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift). Found out that it doesn't really need the size as argument and always gives back the array value at 0th index.